### PR TITLE
feat(jdk17): enhance exception handling for Java 14+ NPE

### DIFF
--- a/actuator/src/main/java/org/tron/core/vm/VM.java
+++ b/actuator/src/main/java/org/tron/core/vm/VM.java
@@ -108,7 +108,10 @@ public class VM {
     } catch (JVMStackOverFlowException | OutOfTimeException e) {
       throw e;
     } catch (RuntimeException e) {
-      if (StringUtils.isEmpty(e.getMessage())) {
+      // https://openjdk.org/jeps/358
+      // https://bugs.openjdk.org/browse/JDK-8220715
+      // since jdk 14, the NullPointerExceptions message is not empty
+      if (e instanceof NullPointerException || StringUtils.isEmpty(e.getMessage())) {
         logger.warn("Unknown Exception occurred, tx id: {}",
             Hex.toHexString(program.getRootTransactionId()), e);
         program.setRuntimeFailure(new RuntimeException("Unknown Exception"));


### PR DESCRIPTION
**What does this PR do?**

   - update condition to check for NullPointerException instances
   - address JEP 358 changes to NullPointerException behavior

   Refs: [JEP 358](https://openjdk.org/jeps/358), [JDK-8220715](https://bugs.openjdk.org/browse/JDK-8220715)

**Why are these changes required?**
   - maintain compatibility with both pre-Java 14 and Java 14+ versions
  - ensure correct handling of non-empty NPE messages in Java 14+

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

