### PR TITLE
feat(jdk17): remove lombok.var

### DIFF
--- a/framework/src/test/java/org/tron/keystroe/CredentialsTest.java
+++ b/framework/src/test/java/org/tron/keystroe/CredentialsTest.java
@@ -1,6 +1,5 @@
 package org.tron.keystroe;
 
-import lombok.var;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -11,24 +10,24 @@ public class CredentialsTest {
 
   @Test
   public void test_equality() {
-    var aObject = new Object();
-    var si = Mockito.mock(SignInterface.class);
-    var si2 = Mockito.mock(SignInterface.class);
-    var si3 = Mockito.mock(SignInterface.class);
-    var address = "TQhZ7W1RudxFdzJMw6FvMnujPxrS6sFfmj".getBytes();
-    var address2 = "TNCmcTdyrYKMtmE1KU2itzeCX76jGm5Not".getBytes();
+    Object aObject = new Object();
+    SignInterface si = Mockito.mock(SignInterface.class);
+    SignInterface si2 = Mockito.mock(SignInterface.class);
+    SignInterface si3 = Mockito.mock(SignInterface.class);
+    byte[] address = "TQhZ7W1RudxFdzJMw6FvMnujPxrS6sFfmj".getBytes();
+    byte[] address2 = "TNCmcTdyrYKMtmE1KU2itzeCX76jGm5Not".getBytes();
     Mockito.when(si.getAddress()).thenReturn(address);
     Mockito.when(si2.getAddress()).thenReturn(address);
     Mockito.when(si3.getAddress()).thenReturn(address2);
-    var aCredential = Credentials.create(si);
+    Credentials aCredential = Credentials.create(si);
     Assert.assertFalse(aObject.equals(aCredential));
     Assert.assertFalse(aCredential.equals(aObject));
     Assert.assertFalse(aCredential.equals(null));
-    var anotherCredential = Credentials.create(si);
-    Assert.assertTrue(aCredential.equals(anotherCredential));            
-    var aCredential2 = Credentials.create(si2);
+    Credentials anotherCredential = Credentials.create(si);
     Assert.assertTrue(aCredential.equals(anotherCredential));
-    var aCredential3 = Credentials.create(si3);
+    Credentials aCredential2 = Credentials.create(si2);
+    Assert.assertTrue(aCredential.equals(anotherCredential));
+    Credentials aCredential3 = Credentials.create(si3);
     Assert.assertFalse(aCredential.equals(aCredential3));
   }
 }


### PR DESCRIPTION
**What does this PR do?**
   remove lombok.var for jdk10+

**Why are these changes required?**
   In JDK 10 and later, you can declare local variables with non-null initializers with the  [var](https://docs.oracle.com/en/java/javase/21/language/local-variable-type-inference.html) identifier, which can help you write code that’s easier to read.

Refs: [JEP 286](https://openjdk.org/jeps/286)

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

