### PR TITLE
feat(jdk17): keep jacoco 0.8.8 for all projects

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,9 @@ subprojects {
     targetCompatibility = JavaVersion.VERSION_1_8
 
     [compileJava, compileTestJava]*.options*.encoding = 'UTF-8'
-
+    jacoco {
+        toolVersion = "0.8.8"
+    }
     buildscript {
         repositories {
             mavenCentral()

--- a/chainbase/build.gradle
+++ b/chainbase/build.gradle
@@ -2,7 +2,6 @@ description = "chainbase – a decentralized database for blockchain."
 
 // Dependency versions
 // ---------------------------------------
-def jacocoVersion = "0.8.0"
 def jansiVersion = "1.16"
 // --------------------------------------
 
@@ -41,9 +40,6 @@ test {
     }
 }
 
-jacoco {
-    toolVersion = jacocoVersion // See http://www.eclemma.org/jacoco/.
-}
 
 jacocoTestReport {
     reports {

--- a/framework/build.gradle
+++ b/framework/build.gradle
@@ -17,9 +17,6 @@ def versions = [
         checkstyle: '8.7',
 ]
 
-jacoco {
-    toolVersion = "0.8.8"
-}
 
 
 configurations {
@@ -157,7 +154,7 @@ jacocoTestReport {
  */
 
 offlinsCoverage {
-    jacocoVersion = '0.8.8' // Optional. By default `0.8.8`
+    jacocoVersion = jacoco.toolVersion
 
     reports {
         html.enabled.set true // Optional. By default `true`

--- a/plugins/build.gradle
+++ b/plugins/build.gradle
@@ -5,9 +5,6 @@ plugins {
 apply plugin: 'application'
 apply plugin: 'checkstyle'
 
-jacoco {
-    toolVersion = "0.8.4"
-}
 def versions = [
         checkstyle: '8.7',
 ]


### PR DESCRIPTION
**What does this PR do?**
    Keep jacoco 0.8.8 for all projects.

**Why are these changes required?**
   Support using Java 17, see  [JaCoCo - Change History](https://www.jacoco.org/jacoco/trunk/doc/changes.html).

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

