### PR TITLE
feat(jdk17): enhance exception handling for NullPointerException

### DIFF
--- a/actuator/src/main/java/org/tron/core/vm/VM.java
+++ b/actuator/src/main/java/org/tron/core/vm/VM.java
@@ -108,7 +108,10 @@ public class VM {
     } catch (JVMStackOverFlowException | OutOfTimeException e) {
       throw e;
     } catch (RuntimeException e) {
-      if (StringUtils.isEmpty(e.getMessage())) {
+      // https://openjdk.org/jeps/358
+      // https://bugs.openjdk.org/browse/JDK-8220715
+      // since jdk 14, the NullPointerExceptions message is not empty
+      if (e instanceof NullPointerException || StringUtils.isEmpty(e.getMessage())) {
         logger.warn("Unknown Exception occurred, tx id: {}",
             Hex.toHexString(program.getRootTransactionId()), e);
         program.setRuntimeFailure(new RuntimeException("Unknown Exception"));


### PR DESCRIPTION
    - update condition to check for NullPointerException instances
    - maintain compatibility with both pre-Java 14 and Java 14+ versions
    - address JEP 358 changes to NullPointerException behavior
    - ensure correct handling of non-empty NPE messages in Java 14+

    Refs: JEP 358, JDK-8220715

**What does this PR do?**

**Why are these changes required?**

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

