### PR TITLE
feat(exception): add TronError for system.exit optimization

### DIFF
--- a/common/src/main/java/org/tron/core/exception/TronError.java
+++ b/common/src/main/java/org/tron/core/exception/TronError.java
@@ -1,0 +1,56 @@
+package org.tron.core.exception;
+
+import lombok.Getter;
+
+/**
+ * If a {@link TronError} is thrown, the service will trigger {@link System#exit(int)} by
+ * {@link Thread#setDefaultUncaughtExceptionHandler(Thread.UncaughtExceptionHandler)}.
+ * NOTE: Do not attempt to catch {@link TronError}.
+ */
+@Getter
+public class TronError extends Error {
+
+  private final ErrCode errCode;
+
+  public TronError(String message, ErrCode exitCode) {
+    super(message);
+    this.errCode = exitCode;
+  }
+
+  public TronError(String message, Throwable cause, ErrCode exitCode) {
+    super(message, cause);
+    this.errCode = exitCode;
+  }
+
+  public TronError(Throwable cause, ErrCode exitCode) {
+    super(cause);
+    this.errCode = exitCode;
+  }
+
+  @Getter
+  public enum ErrCode {
+    WITNESS_KEYSTORE_LOAD(-1),
+    CHECKPOINT_VERSION(-1),
+    LEVELDB_INIT(1),
+    ROCKSDB_INIT(1),
+    DB_FLUSH(1),
+    REWARD_VI_CALCULATOR(1),
+    KHAOS_DB_INIT(1),
+    GENESIS_BLOCK_INIT(1),
+    EVENT_SUBSCRIBE_ERROR(1),
+    AUTO_STOP_PARAMS(1),
+    API_SERVER_INIT(1),
+    SOLID_NODE_INIT(0);
+
+    private final int code;
+
+    ErrCode(int code) {
+      this.code = code;
+    }
+
+    @Override
+    public String toString() {
+      return name() + "(" + code + ")";
+    }
+  }
+}

--- a/framework/src/test/java/org/tron/core/exception/TronErrorTest.java
+++ b/framework/src/test/java/org/tron/core/exception/TronErrorTest.java
@@ -1,0 +1,19 @@
+package org.tron.core.exception;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TronErrorTest {
+
+  @Test
+  public void testTronError() {
+    TronError tronError = new TronError("message", TronError.ErrCode.WITNESS_KEYSTORE_LOAD);
+    Assert.assertEquals(tronError.getErrCode(), TronError.ErrCode.WITNESS_KEYSTORE_LOAD);
+    Assert.assertEquals(tronError.getErrCode().toString(), "WITNESS_KEYSTORE_LOAD(-1)");
+    Assert.assertEquals(tronError.getErrCode().getCode(), -1);
+    tronError = new TronError("message", new Throwable(), TronError.ErrCode.API_SERVER_INIT);
+    Assert.assertEquals(tronError.getErrCode(), TronError.ErrCode.API_SERVER_INIT);
+    tronError = new TronError(new Throwable(), TronError.ErrCode.LEVELDB_INIT);
+    Assert.assertEquals(tronError.getErrCode(), TronError.ErrCode.LEVELDB_INIT);
+  }
+}


### PR DESCRIPTION
**What does this PR do?**

Add `TronError` for `system.exit` optimization.

**Why are these changes required?**

This is the first PR for [Optimize System.exit Usage](https://github.com/tronprotocol/java-tron/issues/6125) and [API Services Fail to Start Silently](https://github.com/tronprotocol/java-tron/issues/5820), API services fail to start  should throw `TronError`,  then `system.exit` is triggered by exitManager.

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

