### PR TITLE
refactor(db): unify database engine initialization

### DIFF
--- a/chainbase/src/main/java/org/tron/core/db/common/DbSourceInter.java
+++ b/chainbase/src/main/java/org/tron/core/db/common/DbSourceInter.java
@@ -15,15 +15,27 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with the ethereumJ library. If not, see <http://www.gnu.org/licenses/>.
  */
+
 package org.tron.core.db.common;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Strings;
+import java.io.File;
+import java.nio.file.Paths;
 import java.util.Map;
 import java.util.Set;
+import org.tron.common.utils.FileUtil;
+import org.tron.common.utils.PropUtil;
 import org.tron.core.db2.common.WrappedByteArray;
+import org.tron.core.exception.TronError;
 
 public interface DbSourceInter<V> extends BatchSourceInter<byte[], V>,
     Iterable<Map.Entry<byte[], V>> {
+
+  String KEY_ENGINE = "ENGINE";
+  String FILE_ENGINE = "engine.properties";
+  String ROCKSDB = "ROCKSDB";
+  String LEVELDB = "LEVELDB";
 
   String getDBName();
 
@@ -53,4 +65,36 @@ public interface DbSourceInter<V> extends BatchSourceInter<byte[], V>,
 
   Map<WrappedByteArray, byte[]> prefixQuery(byte[] key);
 
+  static void checkOrInitEngine(String expectedEngine, String dir, TronError.ErrCode errCode) {
+    String engineFile = Paths.get(dir, FILE_ENGINE).toString();
+    String dbName = Paths.get(dir).getFileName().toString();
+    File currentFile = new File(dir, "CURRENT");
+    if (currentFile.exists() && !Paths.get(engineFile).toFile().exists()
+        && ROCKSDB.equals(expectedEngine)) {
+      // if the CURRENT file exists, but the engine.properties file does not exist, it is LevelDB
+      // 000003.log        CURRENT           LOCK              MANIFEST-000002
+      throw new TronError(
+          String.format("Cannot open %s database '%s' with %s engine.",
+              LEVELDB, dbName, expectedEngine), errCode);
+    }
+    if (FileUtil.createDirIfNotExists(dir)) {
+      if (!FileUtil.createFileIfNotExists(engineFile)) {
+        throw new TronError(String.format("Cannot create file: %s.", engineFile), errCode);
+      }
+    } else {
+      throw new TronError(String.format("Cannot create dir: %s.", dir), errCode);
+    }
+    // for the first init engine
+    String actualEngine = PropUtil.readProperty(engineFile, KEY_ENGINE);
+    if (Strings.isNullOrEmpty(actualEngine)
+        && !PropUtil.writeProperty(engineFile, KEY_ENGINE, expectedEngine)) {
+      throw new TronError(String.format("Cannot write file: %s.", engineFile), errCode);
+    }
+    actualEngine = PropUtil.readProperty(engineFile, KEY_ENGINE);
+    if (!expectedEngine.equals(actualEngine)) {
+      throw new TronError(String.format(
+          "Cannot open %s database '%s' with %s engine.",
+          actualEngine, dbName, expectedEngine), errCode);
+    }
+  }
 }

--- a/framework/src/test/java/org/tron/common/storage/CheckOrInitEngineTest.java
+++ b/framework/src/test/java/org/tron/common/storage/CheckOrInitEngineTest.java
@@ -1,0 +1,263 @@
+package org.tron.common.storage;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mockStatic;
+import static org.tron.core.db.common.DbSourceInter.FILE_ENGINE;
+import static org.tron.core.db.common.DbSourceInter.KEY_ENGINE;
+import static org.tron.core.db.common.DbSourceInter.LEVELDB;
+import static org.tron.core.db.common.DbSourceInter.ROCKSDB;
+import static org.tron.core.db.common.DbSourceInter.checkOrInitEngine;
+
+import com.google.common.base.Strings;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Paths;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.tron.common.utils.FileUtil;
+import org.tron.common.utils.PropUtil;
+import org.tron.core.exception.TronError;
+
+
+public class CheckOrInitEngineTest {
+
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  private static final String ACCOUNT = "account";
+
+  @After
+  public void  clearMocks() {
+    Mockito.clearAllCaches();
+  }
+
+  @Test
+  public void testLevelDbDetectedWhenExpectingRocksDb() throws IOException {
+    try (MockedStatic<FileUtil> fileUtil = mockStatic(FileUtil.class);
+         MockedStatic<PropUtil> propUtil = mockStatic(PropUtil.class);
+         MockedStatic<Strings> strings = mockStatic(Strings.class)) {
+
+      String dir = temporaryFolder.newFolder(ACCOUNT).toString();
+      File currentFile = new File(dir, "CURRENT");
+      assertTrue(currentFile.createNewFile());
+      TronError.ErrCode errCode = TronError.ErrCode.ROCKSDB_INIT;
+      TronError exception = assertThrows(TronError.class, () ->
+          checkOrInitEngine(ROCKSDB, dir, errCode));
+      assertEquals("Cannot open LEVELDB database 'account' with ROCKSDB engine.",
+          exception.getMessage());
+      assertEquals(errCode, exception.getErrCode());
+    }
+  }
+
+  @Test
+  public void testCannotCreateDir() {
+    try (MockedStatic<FileUtil> fileUtil = mockStatic(FileUtil.class)) {
+      String dir = "/invalid/path/that/cannot/be/created";
+
+      fileUtil.when(() -> FileUtil.createDirIfNotExists(dir)).thenReturn(false);
+      TronError.ErrCode errCode = TronError.ErrCode.LEVELDB_INIT;
+      TronError exception = assertThrows(TronError.class, () ->
+          checkOrInitEngine(LEVELDB, dir, errCode));
+      assertEquals("Cannot create dir: " + dir + ".", exception.getMessage());
+      assertEquals(errCode, exception.getErrCode());
+    }
+  }
+
+  @Test
+  public void testCannotCreateEngineFile() throws IOException {
+    try (MockedStatic<FileUtil> fileUtil = mockStatic(FileUtil.class)) {
+      String dir = temporaryFolder.newFolder().toString();
+      String engineFile = Paths.get(dir, FILE_ENGINE).toString();
+      fileUtil.when(() -> FileUtil.createDirIfNotExists(dir)).thenReturn(true);
+      fileUtil.when(() -> FileUtil.createFileIfNotExists(engineFile)).thenReturn(false);
+      TronError.ErrCode errCode = TronError.ErrCode.ROCKSDB_INIT;
+      TronError exception = assertThrows(TronError.class, () ->
+          checkOrInitEngine(ROCKSDB, dir, errCode));
+
+      assertEquals("Cannot create file: " + engineFile + ".", exception.getMessage());
+      assertEquals(errCode, exception.getErrCode());
+    }
+  }
+
+  @Test
+  public void testCannotWritePropertyFile() throws IOException {
+    try (MockedStatic<FileUtil> fileUtil = mockStatic(FileUtil.class);
+         MockedStatic<PropUtil> propUtil = mockStatic(PropUtil.class);
+         MockedStatic<Strings> strings = mockStatic(Strings.class)) {
+
+      String dir = temporaryFolder.newFolder().toString();
+      String engineFile = Paths.get(dir, FILE_ENGINE).toString();
+
+      fileUtil.when(() -> FileUtil.createDirIfNotExists(dir)).thenReturn(true);
+      fileUtil.when(() -> FileUtil.createFileIfNotExists(engineFile)).thenReturn(true);
+
+      propUtil.when(() -> PropUtil.readProperty(engineFile, KEY_ENGINE)).thenReturn(null);
+      strings.when(() -> Strings.isNullOrEmpty(null)).thenReturn(true);
+
+      propUtil.when(() -> PropUtil.writeProperty(engineFile, KEY_ENGINE, ROCKSDB))
+          .thenReturn(false);
+
+      TronError.ErrCode errCode = TronError.ErrCode.LEVELDB_INIT;
+
+      TronError exception = assertThrows(TronError.class, () ->
+          checkOrInitEngine(ROCKSDB, dir, errCode));
+
+      assertEquals("Cannot write file: " + engineFile + ".", exception.getMessage());
+      assertEquals(errCode, exception.getErrCode());
+    }
+
+  }
+
+  @Test
+  public void testEngineMismatch() throws IOException {
+    try (MockedStatic<FileUtil> fileUtil = mockStatic(FileUtil.class);
+         MockedStatic<PropUtil> propUtil = mockStatic(PropUtil.class);
+         MockedStatic<Strings> strings = mockStatic(Strings.class)) {
+
+      String dir = temporaryFolder.newFolder(ACCOUNT).toString();
+      String engineFile = Paths.get(dir, FILE_ENGINE).toString();
+
+      fileUtil.when(() -> FileUtil.createDirIfNotExists(dir)).thenReturn(true);
+      fileUtil.when(() -> FileUtil.createFileIfNotExists(engineFile)).thenReturn(true);
+
+      propUtil.when(() -> PropUtil.readProperty(engineFile, KEY_ENGINE)).thenReturn(LEVELDB);
+      strings.when(() -> Strings.isNullOrEmpty(LEVELDB)).thenReturn(false);
+
+      TronError.ErrCode errCode = TronError.ErrCode.ROCKSDB_INIT;
+
+      TronError exception = assertThrows(TronError.class, () ->
+          checkOrInitEngine(ROCKSDB, dir, errCode));
+
+      assertEquals("Cannot open LEVELDB database '" + ACCOUNT + "' with ROCKSDB engine.",
+          exception.getMessage());
+      assertEquals(errCode, exception.getErrCode());
+    }
+  }
+
+  @Test
+  public void testSuccessfulFirstTimeInit() throws IOException {
+    try (MockedStatic<FileUtil> fileUtil = mockStatic(FileUtil.class);
+         MockedStatic<PropUtil> propUtil = mockStatic(PropUtil.class);
+         MockedStatic<Strings> strings = mockStatic(Strings.class)) {
+
+      String dir = temporaryFolder.newFolder(ACCOUNT).toString();
+      String engineFile = Paths.get(dir, FILE_ENGINE).toString();
+
+      fileUtil.when(() -> FileUtil.createDirIfNotExists(dir)).thenReturn(true);
+      fileUtil.when(() -> FileUtil.createFileIfNotExists(engineFile)).thenReturn(true);
+
+      propUtil.when(() -> PropUtil.readProperty(engineFile, KEY_ENGINE))
+          .thenReturn(null)
+          .thenReturn(LEVELDB);
+      strings.when(() -> Strings.isNullOrEmpty(null)).thenReturn(true);
+
+      propUtil.when(() -> PropUtil.writeProperty(engineFile, KEY_ENGINE, LEVELDB))
+          .thenReturn(true);
+
+      TronError.ErrCode errCode = TronError.ErrCode.LEVELDB_INIT;
+      checkOrInitEngine(LEVELDB, dir, errCode);
+    }
+  }
+
+  @Test
+  public void testSuccessfulExistingEngine() throws IOException {
+    try (MockedStatic<FileUtil> fileUtil = mockStatic(FileUtil.class);
+         MockedStatic<PropUtil> propUtil = mockStatic(PropUtil.class);
+         MockedStatic<Strings> strings = mockStatic(Strings.class)) {
+
+      String dir = temporaryFolder.newFolder(ACCOUNT).toString();
+      String engineFile = Paths.get(dir, FILE_ENGINE).toString();
+
+      fileUtil.when(() -> FileUtil.createDirIfNotExists(dir)).thenReturn(true);
+      fileUtil.when(() -> FileUtil.createFileIfNotExists(engineFile)).thenReturn(true);
+      propUtil.when(() -> PropUtil.readProperty(engineFile, KEY_ENGINE)).thenReturn(ROCKSDB);
+      strings.when(() -> Strings.isNullOrEmpty(ROCKSDB)).thenReturn(false);
+
+      TronError.ErrCode errCode = TronError.ErrCode.ROCKSDB_INIT;
+      checkOrInitEngine(ROCKSDB, dir, errCode);
+    }
+  }
+
+  @Test
+  /**
+   * 000003.log   CURRENT  LOCK MANIFEST-000002
+   */
+  public void testCurrentFileExistsWithNoEngineFile() throws IOException {
+    try (MockedStatic<FileUtil> fileUtil = mockStatic(FileUtil.class);
+         MockedStatic<PropUtil> propUtil = mockStatic(PropUtil.class);
+         MockedStatic<Strings> strings = mockStatic(Strings.class)) {
+
+      String dir = temporaryFolder.newFolder(ACCOUNT).toString();
+      String engineFile = Paths.get(dir, FILE_ENGINE).toString();
+      File currentFile = new File(dir, "CURRENT");
+      assertTrue(currentFile.createNewFile());
+
+      fileUtil.when(() -> FileUtil.createDirIfNotExists(dir)).thenReturn(true);
+      fileUtil.when(() -> FileUtil.createFileIfNotExists(engineFile)).thenReturn(true);
+      propUtil.when(() -> PropUtil.readProperty(engineFile, KEY_ENGINE)).thenReturn(LEVELDB);
+      strings.when(() -> Strings.isNullOrEmpty(LEVELDB)).thenReturn(false);
+
+      TronError.ErrCode errCode = TronError.ErrCode.LEVELDB_INIT;
+
+      checkOrInitEngine(LEVELDB, dir, errCode);
+    }
+  }
+
+  @Test
+  /**
+   * 000003.log   CURRENT  LOCK MANIFEST-000002  engine.properties(RocksDB)
+   */
+  public void testCurrentFileExistsEngineFileExists() throws IOException {
+    try (MockedStatic<FileUtil> fileUtil = mockStatic(FileUtil.class);
+         MockedStatic<PropUtil> propUtil = mockStatic(PropUtil.class);
+         MockedStatic<Strings> strings = mockStatic(Strings.class)) {
+
+      String dir = temporaryFolder.newFolder(ACCOUNT).toString();
+      String engineFile = Paths.get(dir, FILE_ENGINE).toString();
+
+      File currentFile = new File(dir, "CURRENT");
+      File engineFileObj = new File(engineFile);
+      assertTrue(currentFile.createNewFile());
+      assertTrue(engineFileObj.createNewFile());
+
+
+      fileUtil.when(() -> FileUtil.createDirIfNotExists(dir)).thenReturn(true);
+      fileUtil.when(() -> FileUtil.createFileIfNotExists(engineFile)).thenReturn(true);
+
+      propUtil.when(() -> PropUtil.readProperty(engineFile, KEY_ENGINE)).thenReturn(ROCKSDB);
+      strings.when(() -> Strings.isNullOrEmpty(ROCKSDB)).thenReturn(false);
+
+      TronError.ErrCode errCode = TronError.ErrCode.ROCKSDB_INIT;
+      checkOrInitEngine(ROCKSDB, dir, errCode);
+    }
+  }
+
+  @Test
+  public void testEmptyStringEngine() throws IOException {
+    try (MockedStatic<FileUtil> fileUtil = mockStatic(FileUtil.class);
+         MockedStatic<PropUtil> propUtil = mockStatic(PropUtil.class);
+         MockedStatic<Strings> strings = mockStatic(Strings.class)) {
+
+      String dir = temporaryFolder.newFolder("account").toString();
+      String engineFile = Paths.get(dir, FILE_ENGINE).toString();
+
+      fileUtil.when(() -> FileUtil.createDirIfNotExists(dir)).thenReturn(true);
+      fileUtil.when(() -> FileUtil.createFileIfNotExists(engineFile)).thenReturn(true);
+
+      propUtil.when(() -> PropUtil.readProperty(engineFile, KEY_ENGINE))
+          .thenReturn("").thenReturn(ROCKSDB);
+      strings.when(() -> Strings.isNullOrEmpty("")).thenReturn(true);
+
+      propUtil.when(() -> PropUtil.writeProperty(engineFile, KEY_ENGINE, ROCKSDB))
+          .thenReturn(true);
+      TronError.ErrCode errCode = TronError.ErrCode.ROCKSDB_INIT;
+      checkOrInitEngine(ROCKSDB, dir, errCode);
+    }
+  }
+}

--- a/framework/src/test/java/org/tron/common/storage/leveldb/LevelDbDataSourceImplTest.java
+++ b/framework/src/test/java/org/tron/common/storage/leveldb/LevelDbDataSourceImplTest.java
@@ -421,11 +421,9 @@ public class LevelDbDataSourceImplTest {
     try {
       dataSource = new LevelDbDataSourceImpl(dir, "test_engine");
       dataSource.initDB();
-    } catch (Exception e) {
+    } catch (TronError e) {
       Assert.assertEquals(String.format(
-              "Cannot open RocksDB database '%s' with LevelDB engine."
-                  + " Set db.engine=ROCKSDB or use LevelDB database. ", "test_engine"),
-          e.getMessage());
+          "Cannot open ROCKSDB database '%s' with LEVELDB engine.", "test_engine"), e.getMessage());
     }
   }
 
@@ -442,8 +440,7 @@ public class LevelDbDataSourceImplTest {
     LevelDbDataSourceImpl levelDB =
         new LevelDbDataSourceImpl(StorageUtils.getOutputDirectoryByDbName(name), name);
     exception.expectMessage(String.format(
-        "Cannot open RocksDB database '%s' with LevelDB engine."
-            + " Set db.engine=ROCKSDB or use LevelDB database. ", name));
+        "Cannot open ROCKSDB database '%s' with LEVELDB engine.", name));
     levelDB.initDB();
   }
 

--- a/framework/src/test/java/org/tron/common/storage/rocksdb/RocksDbDataSourceImplTest.java
+++ b/framework/src/test/java/org/tron/common/storage/rocksdb/RocksDbDataSourceImplTest.java
@@ -1,4 +1,4 @@
-package org.tron.common.storage.leveldb;
+package org.tron.common.storage.rocksdb;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -34,7 +34,7 @@ import org.rocksdb.RocksDBException;
 import org.tron.common.error.TronDBException;
 import org.tron.common.parameter.CommonParameter;
 import org.tron.common.storage.WriteOptionsWrapper;
-import org.tron.common.storage.rocksdb.RocksDbDataSourceImpl;
+import org.tron.common.storage.leveldb.LevelDbDataSourceImpl;
 import org.tron.common.utils.ByteArray;
 import org.tron.common.utils.FileUtil;
 import org.tron.common.utils.PropUtil;
@@ -314,11 +314,9 @@ public class RocksDbDataSourceImplTest {
     dataSource = new RocksDbDataSourceImpl(dir, "test_engine");
     try {
       dataSource.initDB();
-    } catch (Exception e) {
+    } catch (TronError e) {
       Assert.assertEquals(String.format(
-              "Cannot open LevelDB database '%s' with RocksDB engine."
-                  + " Set db.engine=LEVELDB or use RocksDB database. ", "test_engine"),
-              e.getMessage());
+          "Cannot open LEVELDB database '%s' with ROCKSDB engine.", "test_engine"), e.getMessage());
     }
     Assert.assertNull(dataSource.getDatabase());
     PropUtil.writeProperty(enginePath, "ENGINE", "ROCKSDB");
@@ -449,9 +447,7 @@ public class RocksDbDataSourceImplTest {
     levelDb.closeDB();
     RocksDbDataSourceImpl rocksDb = new RocksDbDataSourceImpl(output, name);
     expectedException.expectMessage(
-        String.format(
-            "Cannot open LevelDB database '%s' with RocksDB engine."
-                + " Set db.engine=LEVELDB or use RocksDB database. ", name));
+        String.format("Cannot open LEVELDB database '%s' with ROCKSDB engine.", name));
     rocksDb.initDB();
   }
 
@@ -475,9 +471,7 @@ public class RocksDbDataSourceImplTest {
     Assert.assertFalse(engineFile.exists());
     RocksDbDataSourceImpl rocksDb = new RocksDbDataSourceImpl(output, name);
     expectedException.expectMessage(
-        String.format(
-            "Cannot open LevelDB database '%s' with RocksDB engine."
-                + " Set db.engine=LEVELDB or use RocksDB database. ", name));
+        String.format("Cannot open LEVELDB database '%s' with ROCKSDB engine.", name));
     rocksDb.initDB();
   }
 


### PR DESCRIPTION


**What does this PR do?**
       Unify database engine initialization.
**Why are these changes required?**
    - Consolidate duplicate engine initialization logic from two separate classes into a single unified method
    - Enhance LevelDB/RocksDB compatibility detection with clearer error messages
    - Improve error handling for directory/file creation failures
**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

