### PR TITLE
log(http): workaround CodeQL java/error-message-exposure

### DIFF
--- a/framework/src/main/java/org/tron/core/services/http/GetBrokerageServlet.java
+++ b/framework/src/main/java/org/tron/core/services/http/GetBrokerageServlet.java
@@ -28,7 +28,8 @@ public class GetBrokerageServlet extends RateLimiterServlet {
       response.getWriter().println("{\"brokerage\": " + value + "}");
     } catch (DecoderException | IllegalArgumentException e) {
       try {
-        response.getWriter().println("{\"Error\": " + "\"INVALID address\"}");
+        String message = e.getMessage();
+        response.getWriter().println("{\"Error\": " + "\"INVALID address, " + message + "\"}");
       } catch (IOException ioe) {
         logger.debug("IOException: {}", ioe.getMessage());
       }

--- a/framework/src/main/java/org/tron/core/services/http/GetRewardServlet.java
+++ b/framework/src/main/java/org/tron/core/services/http/GetRewardServlet.java
@@ -27,7 +27,8 @@ public class GetRewardServlet extends RateLimiterServlet {
       response.getWriter().println("{\"reward\": " + value + "}");
     } catch (DecoderException | IllegalArgumentException e) {
       try {
-        response.getWriter().println("{\"Error\": " + "\"INVALID address\"}");
+        String message = e.getMessage();
+        response.getWriter().println("{\"Error\": " + "\"INVALID address, " + message + "\"}");
       } catch (IOException ioe) {
         logger.debug("IOException: {}", ioe.getMessage());
       }

--- a/framework/src/main/java/org/tron/core/services/http/solidity/GetTransactionByIdSolidityServlet.java
+++ b/framework/src/main/java/org/tron/core/services/http/solidity/GetTransactionByIdSolidityServlet.java
@@ -30,7 +30,12 @@ public class GetTransactionByIdSolidityServlet extends RateLimiterServlet {
       String input = request.getParameter("value");
       fillResponse(ByteString.copyFrom(ByteArray.fromHexString(input)), visible, response);
     } catch (Exception e) {
-      Util.processError(e, response);
+      logger.debug("Exception: {}", e.getMessage());
+      try {
+        response.getWriter().println(e.getMessage());
+      } catch (IOException ioe) {
+        logger.debug("IOException: {}", ioe.getMessage());
+      }
     }
   }
 
@@ -41,7 +46,13 @@ public class GetTransactionByIdSolidityServlet extends RateLimiterServlet {
       JsonFormat.merge(params.getParams(), build, params.isVisible());
       fillResponse(build.build().getValue(), params.isVisible(), response);
     } catch (Exception e) {
-      Util.processError(e, response);
+      logger.debug("Exception: {}", e.getMessage());
+      try {
+        String message = e.getMessage();
+        response.getWriter().println(message);
+      } catch (IOException ioe) {
+        logger.debug("IOException: {}", ioe.getMessage());
+      }
     }
   }
 

--- a/framework/src/main/java/org/tron/core/services/http/solidity/GetTransactionInfoByIdSolidityServlet.java
+++ b/framework/src/main/java/org/tron/core/services/http/solidity/GetTransactionInfoByIdSolidityServlet.java
@@ -1,6 +1,7 @@
 package org.tron.core.services.http.solidity;
 
 import com.google.protobuf.ByteString;
+import java.io.IOException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
@@ -36,7 +37,13 @@ public class GetTransactionInfoByIdSolidityServlet extends RateLimiterServlet {
         response.getWriter().println(JsonFormat.printToString(transInfo, visible));
       }
     } catch (Exception e) {
-      Util.processError(e, response);
+      logger.debug("Exception: {}", e.getMessage());
+      try {
+        String message = e.getMessage();
+        response.getWriter().println(message);
+      } catch (IOException ioe) {
+        logger.debug("IOException: {}", ioe.getMessage());
+      }
     }
   }
 
@@ -54,7 +61,13 @@ public class GetTransactionInfoByIdSolidityServlet extends RateLimiterServlet {
         response.getWriter().println(JsonFormat.printToString(transInfo, params.isVisible()));
       }
     } catch (Exception e) {
-      Util.processError(e, response);
+      logger.debug("Exception: {}", e.getMessage());
+      try {
+        String message = e.getMessage();
+        response.getWriter().println(message);
+      } catch (IOException ioe) {
+        logger.debug("IOException: {}", ioe.getMessage());
+      }
     }
   }
 


### PR DESCRIPTION
  Applied a trick to suppress the CodeQL warning while keeping the error response format unchanged.

**What does this PR do?**

**Why are these changes required?**

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

