### PR TITLE
feat(metrics): add block transaction count and SR set change monitoring

### DIFF
--- a/common/src/main/java/org/tron/common/prometheus/MetricKeys.java
+++ b/common/src/main/java/org/tron/common/prometheus/MetricKeys.java
@@ -14,7 +14,6 @@ public class MetricKeys {
     public static final String TXS = "tron:txs";
     public static final String MINER = "tron:miner";
     public static final String BLOCK_FORK = "tron:block_fork";
-    public static final String BLOCK_EMPTY = "tron:block_empty";
     public static final String SR_SET_CHANGE = "tron:sr_set_change";
     public static final String P2P_ERROR = "tron:p2p_error";
     public static final String P2P_DISCONNECT = "tron:p2p_disconnect";
@@ -64,6 +63,7 @@ public class MetricKeys {
     public static final String MESSAGE_PROCESS_LATENCY = "tron:message_process_latency_seconds";
     public static final String BLOCK_FETCH_LATENCY = "tron:block_fetch_latency_seconds";
     public static final String BLOCK_RECEIVE_DELAY = "tron:block_receive_delay_seconds";
+    public static final String BLOCK_TRANSACTION_COUNT = "tron:block_transaction_count";
 
     private Histogram() {
       throw new IllegalStateException("Histogram");

--- a/common/src/main/java/org/tron/common/prometheus/MetricKeys.java
+++ b/common/src/main/java/org/tron/common/prometheus/MetricKeys.java
@@ -14,6 +14,8 @@ public class MetricKeys {
     public static final String TXS = "tron:txs";
     public static final String MINER = "tron:miner";
     public static final String BLOCK_FORK = "tron:block_fork";
+    public static final String BLOCK_EMPTY = "tron:block_empty";
+    public static final String SR_SET_CHANGE = "tron:sr_set_change";
     public static final String P2P_ERROR = "tron:p2p_error";
     public static final String P2P_DISCONNECT = "tron:p2p_disconnect";
     public static final String INTERNAL_SERVICE_FAIL = "tron:internal_service_fail";

--- a/common/src/main/java/org/tron/common/prometheus/MetricLabels.java
+++ b/common/src/main/java/org/tron/common/prometheus/MetricLabels.java
@@ -31,6 +31,8 @@ public class MetricLabels {
     public static final String TXS_FAIL_SIG = "sig";
     public static final String TXS_FAIL_TAPOS = "tapos";
     public static final String TXS_FAIL_DUP = "dup";
+    public static final String SR_ADD = "add";
+    public static final String SR_REMOVE = "remove";
 
     private Counter() {
       throw new IllegalStateException("Counter");

--- a/common/src/main/java/org/tron/common/prometheus/MetricsCounter.java
+++ b/common/src/main/java/org/tron/common/prometheus/MetricsCounter.java
@@ -14,7 +14,6 @@ class MetricsCounter {
     init(MetricKeys.Counter.TXS, "tron  txs  info .", "type", "detail");
     init(MetricKeys.Counter.MINER, "tron  miner info .", "miner", "type");
     init(MetricKeys.Counter.BLOCK_FORK, "tron  block fork info .", "type");
-    init(MetricKeys.Counter.BLOCK_EMPTY, "tron  empty block count .", "miner");
     init(MetricKeys.Counter.SR_SET_CHANGE, "tron sr set change .", "action", "witness");
     init(MetricKeys.Counter.P2P_ERROR, "tron p2p error  info .", "type");
     init(MetricKeys.Counter.P2P_DISCONNECT, "tron p2p disconnect .", "type");

--- a/common/src/main/java/org/tron/common/prometheus/MetricsCounter.java
+++ b/common/src/main/java/org/tron/common/prometheus/MetricsCounter.java
@@ -14,6 +14,8 @@ class MetricsCounter {
     init(MetricKeys.Counter.TXS, "tron  txs  info .", "type", "detail");
     init(MetricKeys.Counter.MINER, "tron  miner info .", "miner", "type");
     init(MetricKeys.Counter.BLOCK_FORK, "tron  block fork info .", "type");
+    init(MetricKeys.Counter.BLOCK_EMPTY, "tron  empty block count .", "miner");
+    init(MetricKeys.Counter.SR_SET_CHANGE, "tron sr set change .", "action", "witness");
     init(MetricKeys.Counter.P2P_ERROR, "tron p2p error  info .", "type");
     init(MetricKeys.Counter.P2P_DISCONNECT, "tron p2p disconnect .", "type");
     init(MetricKeys.Counter.INTERNAL_SERVICE_FAIL, "internal Service fail.",

--- a/common/src/main/java/org/tron/common/prometheus/MetricsHistogram.java
+++ b/common/src/main/java/org/tron/common/prometheus/MetricsHistogram.java
@@ -9,6 +9,7 @@ import lombok.extern.slf4j.Slf4j;
 public class MetricsHistogram {
 
   private static final Map<String, Histogram> container = new ConcurrentHashMap<>();
+  private static final String MINER_LABEL = "miner";
 
   static {
     init(MetricKeys.Histogram.INTERNAL_SERVICE_LATENCY, "Internal Service latency.",
@@ -20,7 +21,7 @@ public class MetricsHistogram {
     init(MetricKeys.Histogram.JSONRPC_SERVICE_LATENCY, "JsonRpc Service latency.",
         "method");
     init(MetricKeys.Histogram.MINER_LATENCY, "miner latency.",
-        "miner");
+        MINER_LABEL);
     init(MetricKeys.Histogram.PING_PONG_LATENCY, "node  ping pong  latency.");
     init(MetricKeys.Histogram.VERIFY_SIGN_LATENCY, "verify sign latency for trx , block.",
         "type");
@@ -36,7 +37,7 @@ public class MetricsHistogram {
     init(MetricKeys.Histogram.PROCESS_TRANSACTION_LATENCY, "process transaction latency.",
         "type", "contract");
     init(MetricKeys.Histogram.MINER_DELAY, "miner delay time, actualTime - planTime.",
-        "miner");
+        MINER_LABEL);
     init(MetricKeys.Histogram.UDP_BYTES, "udp_bytes traffic.",
         "type");
     init(MetricKeys.Histogram.TCP_BYTES, "tcp_bytes traffic.",
@@ -52,7 +53,7 @@ public class MetricsHistogram {
     init(MetricKeys.Histogram.BLOCK_TRANSACTION_COUNT,
         "Distribution of transaction counts per block.",
         new double[]{0, 10, 50, 100, 200, 500, 1000, 2000, 5000, 10000},
-        "miner");
+        MINER_LABEL);
   }
 
   private MetricsHistogram() {

--- a/common/src/main/java/org/tron/common/prometheus/MetricsHistogram.java
+++ b/common/src/main/java/org/tron/common/prometheus/MetricsHistogram.java
@@ -48,6 +48,11 @@ public class MetricsHistogram {
     init(MetricKeys.Histogram.BLOCK_FETCH_LATENCY, "fetch block latency.");
     init(MetricKeys.Histogram.BLOCK_RECEIVE_DELAY,
         "receive block delay time, receiveTime - blockTime.");
+
+    init(MetricKeys.Histogram.BLOCK_TRANSACTION_COUNT,
+        "Distribution of transaction counts per block.",
+        new double[]{0, 10, 50, 100, 200, 500, 1000, 2000, 5000, 10000},
+        "miner");
   }
 
   private MetricsHistogram() {
@@ -60,6 +65,17 @@ public class MetricsHistogram {
         .help(help)
         .labelNames(labels)
         .register());
+  }
+
+  private static void init(String name, String help, double[] buckets, String... labels) {
+    Histogram.Builder builder = Histogram.build()
+        .name(name)
+        .help(help)
+        .labelNames(labels);
+    if (buckets != null && buckets.length > 0) {
+      builder.buckets(buckets);
+    }
+    container.put(name, builder.register());
   }
 
   static Histogram.Timer startTimer(String key, String... labels) {

--- a/framework/src/main/java/org/tron/core/metrics/blockchain/BlockChainMetricManager.java
+++ b/framework/src/main/java/org/tron/core/metrics/blockchain/BlockChainMetricManager.java
@@ -174,11 +174,11 @@ public class BlockChainMetricManager {
       MetricsUtil.meterMark(MetricsKey.BLOCKCHAIN_TPS, block.getTransactions().size());
       Metrics.counterInc(MetricKeys.Counter.TXS, block.getTransactions().size(),
           MetricLabels.Counter.TXS_SUCCESS, MetricLabels.Counter.TXS_SUCCESS);
-    } else {
-      // Empty block
-      Metrics.counterInc(MetricKeys.Counter.BLOCK_EMPTY, 1,
-          StringUtil.encode58Check(address));
     }
+    // Record transaction count distribution for all blocks (including empty blocks)
+    int txCount = block.getTransactions().size();
+    Metrics.histogramObserve(MetricKeys.Histogram.BLOCK_TRANSACTION_COUNT, txCount,
+        StringUtil.encode58Check(address));
 
     // SR set change detection
     long nextMaintenanceTime = dbManager.getDynamicPropertiesStore().getNextMaintenanceTime();

--- a/framework/src/main/java/org/tron/core/metrics/blockchain/BlockChainMetricManager.java
+++ b/framework/src/main/java/org/tron/core/metrics/blockchain/BlockChainMetricManager.java
@@ -47,7 +47,7 @@ public class BlockChainMetricManager {
   private String failProcessBlockReason = "";
   private final Set<String> lastActiveWitnesses = ConcurrentHashMap.newKeySet();
   // To control SR set change metric update logic, -1 means not initialized
-  private long lastNextMaintenanceTime = -1; 
+  private long lastNextMaintenanceTime = -1;
 
   public BlockChainInfo getBlockChainInfo() {
     BlockChainInfo blockChainInfo = new BlockChainInfo();

--- a/framework/src/main/java/org/tron/core/metrics/blockchain/BlockChainMetricManager.java
+++ b/framework/src/main/java/org/tron/core/metrics/blockchain/BlockChainMetricManager.java
@@ -46,7 +46,8 @@ public class BlockChainMetricManager {
   @Setter
   private String failProcessBlockReason = "";
   private final Set<String> lastActiveWitnesses = ConcurrentHashMap.newKeySet();
-  private long lastNextMaintenanceTime = 0;
+  // To control SR set change metric update logic, -1 means not initialized
+  private long lastNextMaintenanceTime = -1; 
 
   public BlockChainInfo getBlockChainInfo() {
     BlockChainInfo blockChainInfo = new BlockChainInfo();
@@ -181,7 +182,7 @@ public class BlockChainMetricManager {
 
     // SR set change detection
     long nextMaintenanceTime = dbManager.getDynamicPropertiesStore().getNextMaintenanceTime();
-    if (lastNextMaintenanceTime == 0) {
+    if (lastNextMaintenanceTime == -1) {
       lastNextMaintenanceTime = nextMaintenanceTime;
       lastActiveWitnesses.addAll(chainBaseManager.getWitnessScheduleStore().getActiveWitnesses()
           .stream().map(w -> Hex.toHexString(w.toByteArray())).collect(Collectors.toSet()));
@@ -196,13 +197,6 @@ public class BlockChainMetricManager {
   }
 
   private void recordSrSetChange(Set<String> currentWitnesses) {
-    if (currentWitnesses.isEmpty()) {
-      return;
-    }
-    if (lastActiveWitnesses.isEmpty()) {
-      lastActiveWitnesses.addAll(currentWitnesses);
-      return;
-    }
     Set<String> added = new HashSet<>(currentWitnesses);
     added.removeAll(lastActiveWitnesses);
 

--- a/framework/src/main/java/org/tron/core/metrics/blockchain/BlockChainMetricManager.java
+++ b/framework/src/main/java/org/tron/core/metrics/blockchain/BlockChainMetricManager.java
@@ -46,6 +46,7 @@ public class BlockChainMetricManager {
   @Setter
   private String failProcessBlockReason = "";
   private final Set<String> lastActiveWitnesses = ConcurrentHashMap.newKeySet();
+  private long lastNextMaintenanceTime = 0;
 
   public BlockChainInfo getBlockChainInfo() {
     BlockChainInfo blockChainInfo = new BlockChainInfo();
@@ -179,11 +180,19 @@ public class BlockChainMetricManager {
     }
 
     // SR set change detection
-    Set<String> currentWitnesses = chainBaseManager.getWitnessScheduleStore().getActiveWitnesses()
-        .stream()
-        .map(w -> Hex.toHexString(w.toByteArray()))
-        .collect(Collectors.toSet());
-    recordSrSetChange(currentWitnesses);
+    long nextMaintenanceTime = dbManager.getDynamicPropertiesStore().getNextMaintenanceTime();
+    if (lastNextMaintenanceTime == 0) {
+      lastNextMaintenanceTime = nextMaintenanceTime;
+      lastActiveWitnesses.addAll(chainBaseManager.getWitnessScheduleStore().getActiveWitnesses()
+          .stream().map(w -> Hex.toHexString(w.toByteArray())).collect(Collectors.toSet()));
+    } else if (nextMaintenanceTime != lastNextMaintenanceTime) {
+      Set<String> currentWitnesses = chainBaseManager.getWitnessScheduleStore().getActiveWitnesses()
+          .stream()
+          .map(w -> Hex.toHexString(w.toByteArray()))
+          .collect(Collectors.toSet());
+      recordSrSetChange(currentWitnesses);
+      lastNextMaintenanceTime = nextMaintenanceTime;
+    }
   }
 
   private void recordSrSetChange(Set<String> currentWitnesses) {

--- a/framework/src/main/java/org/tron/core/metrics/blockchain/BlockChainMetricManager.java
+++ b/framework/src/main/java/org/tron/core/metrics/blockchain/BlockChainMetricManager.java
@@ -3,10 +3,13 @@ package org.tron.core.metrics.blockchain;
 import com.codahale.metrics.Counter;
 import com.google.protobuf.ByteString;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.SortedMap;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 import lombok.Getter;
 import lombok.Setter;
 import org.bouncycastle.util.encoders.Hex;
@@ -42,6 +45,7 @@ public class BlockChainMetricManager {
   private long failProcessBlockNum = 0;
   @Setter
   private String failProcessBlockReason = "";
+  private final Set<String> lastActiveWitnesses = ConcurrentHashMap.newKeySet();
 
   public BlockChainInfo getBlockChainInfo() {
     BlockChainInfo blockChainInfo = new BlockChainInfo();
@@ -168,6 +172,45 @@ public class BlockChainMetricManager {
       MetricsUtil.meterMark(MetricsKey.BLOCKCHAIN_TPS, block.getTransactions().size());
       Metrics.counterInc(MetricKeys.Counter.TXS, block.getTransactions().size(),
           MetricLabels.Counter.TXS_SUCCESS, MetricLabels.Counter.TXS_SUCCESS);
+    } else {
+      // Empty block
+      Metrics.counterInc(MetricKeys.Counter.BLOCK_EMPTY, 1,
+          StringUtil.encode58Check(address));
+    }
+
+    // SR set change detection
+    Set<String> currentWitnesses = chainBaseManager.getWitnessScheduleStore().getActiveWitnesses()
+        .stream()
+        .map(w -> Hex.toHexString(w.toByteArray()))
+        .collect(Collectors.toSet());
+    recordSrSetChange(currentWitnesses);
+  }
+
+  private void recordSrSetChange(Set<String> currentWitnesses) {
+    if (currentWitnesses.isEmpty()) {
+      return;
+    }
+    if (lastActiveWitnesses.isEmpty()) {
+      lastActiveWitnesses.addAll(currentWitnesses);
+      return;
+    }
+    Set<String> added = new HashSet<>(currentWitnesses);
+    added.removeAll(lastActiveWitnesses);
+
+    Set<String> removed = new HashSet<>(lastActiveWitnesses);
+    removed.removeAll(currentWitnesses);
+
+    for (String address : added) {
+      Metrics.counterInc(MetricKeys.Counter.SR_SET_CHANGE, 1,
+          MetricLabels.Counter.SR_ADD, StringUtil.encode58Check(Hex.decode(address)));
+    }
+    for (String address : removed) {
+      Metrics.counterInc(MetricKeys.Counter.SR_SET_CHANGE, 1,
+          MetricLabels.Counter.SR_REMOVE, StringUtil.encode58Check(Hex.decode(address)));
+    }
+    if (!added.isEmpty() || !removed.isEmpty()) {
+      lastActiveWitnesses.clear();
+      lastActiveWitnesses.addAll(currentWitnesses);
     }
   }
 

--- a/framework/src/test/java/org/tron/core/metrics/prometheus/PrometheusApiServiceTest.java
+++ b/framework/src/test/java/org/tron/core/metrics/prometheus/PrometheusApiServiceTest.java
@@ -25,6 +25,7 @@ import org.tron.common.prometheus.Metrics;
 import org.tron.common.utils.ByteArray;
 import org.tron.common.utils.PublicMethod;
 import org.tron.common.utils.Sha256Hash;
+import org.tron.common.utils.StringUtil;
 import org.tron.common.utils.Utils;
 import org.tron.consensus.dpos.DposSlot;
 import org.tron.core.ChainBaseManager;
@@ -65,7 +66,7 @@ public class PrometheusApiServiceTest extends BaseTest {
     parameter.setMetricsPrometheusEnable(true);
   }
 
-  protected void check() throws Exception {
+  protected void check(byte[] address) throws Exception {
     Double memoryBytes = CollectorRegistry.defaultRegistry.getSampleValue(
         "system_total_physical_memory_bytes");
     Assert.assertNotNull(memoryBytes);
@@ -80,6 +81,17 @@ public class PrometheusApiServiceTest extends BaseTest {
         new String[] {"sync"}, new String[] {"false"});
     Assert.assertNotNull(pushBlock);
     Assert.assertEquals(pushBlock.intValue(), blocks + 1);
+
+    String minerBase58 = StringUtil.encode58Check(address);
+    Double emptyBlock = CollectorRegistry.defaultRegistry.getSampleValue(
+        "tron:block_empty_total", new String[] {"miner"}, new String[] {minerBase58});
+
+    Assert.assertNotNull(emptyBlock);
+    // The initial address is in the active witness list along with 2 randomly generated witnesses,
+    // so it produces blocks every 3 slots. Total empty blocks = 1 (first manual block) + blocks/3
+    // (from the loop) + 1 if blocks%3 != 0 (partial round)
+    Assert.assertEquals(emptyBlock.intValue(), 1 + blocks / 3 + (blocks % 3 != 0 ? 1 : 0));
+
     Double errorLogs = CollectorRegistry.defaultRegistry.getSampleValue(
         "tron:error_info_total", new String[] {"net"}, new String[] {MetricLabels.UNDEFINED});
     Assert.assertNull(errorLogs);
@@ -133,7 +145,7 @@ public class PrometheusApiServiceTest extends BaseTest {
     for (int i = 0; i < blocks; i++) {
       generateBlock(witnessAndAccount);
     }
-    check();
+    check(address);
   }
 
   private Map<ByteString, String> addTestWitnessAndAccount() {

--- a/framework/src/test/java/org/tron/core/metrics/prometheus/PrometheusApiServiceTest.java
+++ b/framework/src/test/java/org/tron/core/metrics/prometheus/PrometheusApiServiceTest.java
@@ -40,6 +40,9 @@ import org.tron.protos.Protocol;
 
 @Slf4j(topic = "metric")
 public class PrometheusApiServiceTest extends BaseTest {
+
+  private static final String MINER_LABEL = "miner";
+
   static LocalDateTime localDateTime = LocalDateTime.now();
   @Resource
   private DposSlot dposSlot;
@@ -87,7 +90,7 @@ public class PrometheusApiServiceTest extends BaseTest {
     // Query histogram bucket le="0.0" for empty blocks
     Double emptyBlock = CollectorRegistry.defaultRegistry.getSampleValue(
         "tron:block_transaction_count_bucket",
-        new String[] {"miner", "le"}, new String[] {minerBase58, "0.0"});
+        new String[] {MINER_LABEL, "le"}, new String[] {minerBase58, "0.0"});
     
     Assert.assertNotNull("Empty block bucket should exist for miner: " + minerBase58, emptyBlock);
     Assert.assertEquals("Should have 1 empty block", 1, emptyBlock.intValue());
@@ -125,7 +128,7 @@ public class PrometheusApiServiceTest extends BaseTest {
       // Collect empty blocks count from histogram bucket
       Double witnessEmptyBlock = CollectorRegistry.defaultRegistry.getSampleValue(
           "tron:block_transaction_count_bucket",
-          new String[] {"miner", "le"}, new String[] {witnessBase58, "0.0"});
+          new String[] {MINER_LABEL, "le"}, new String[] {witnessBase58, "0.0"});
       Assert.assertNotNull("Empty block bucket should exist for witness: " + witnessBase58,
           witnessEmptyBlock);
       totalNewWitnessEmptyBlocks += witnessEmptyBlock;

--- a/framework/src/test/java/org/tron/core/metrics/prometheus/PrometheusApiServiceTest.java
+++ b/framework/src/test/java/org/tron/core/metrics/prometheus/PrometheusApiServiceTest.java
@@ -84,11 +84,13 @@ public class PrometheusApiServiceTest extends BaseTest {
     Assert.assertEquals(pushBlock.intValue(), blocks + 1);
 
     String minerBase58 = StringUtil.encode58Check(address);
+    // Query histogram bucket le="0.0" for empty blocks
     Double emptyBlock = CollectorRegistry.defaultRegistry.getSampleValue(
-        "tron:block_empty_total", new String[] {"miner"}, new String[] {minerBase58});
-
-    Assert.assertNotNull(emptyBlock);
-    Assert.assertEquals(emptyBlock.intValue(), 1);
+        "tron:block_transaction_count_bucket",
+        new String[] {"miner", "le"}, new String[] {minerBase58, "0.0"});
+    
+    Assert.assertNotNull("Empty block bucket should exist for miner: " + minerBase58, emptyBlock);
+    Assert.assertEquals("Should have 1 empty block", 1, emptyBlock.intValue());
 
     // Check SR_REMOVE for initial address (removed when addTestWitnessAndAccount() is called)
     Double srRemoveCount = CollectorRegistry.defaultRegistry.getSampleValue(
@@ -99,7 +101,8 @@ public class PrometheusApiServiceTest extends BaseTest {
     Assert.assertNotNull(srRemoveCount);
     Assert.assertEquals(1, srRemoveCount.intValue());
 
-    // Check SR_ADD and empty blocks for each new witness in witnessAndAccount (excluding initial address)
+    // Check SR_ADD and empty blocks for each new witness in witnessAndAccount
+    // (excluding initial address)
     ByteString addressByteString = ByteString.copyFrom(address);
     double totalNewWitnessEmptyBlocks = 0;
     for (ByteString witnessAddress : witnessAndAccount.keySet()) {
@@ -114,13 +117,17 @@ public class PrometheusApiServiceTest extends BaseTest {
           new String[] {"action", "witness"},
           new String[] {MetricLabels.Counter.SR_ADD, witnessBase58}
       );
-      Assert.assertNotNull("SR_ADD should be recorded for witness: " + witnessBase58, srAddCount);
-      Assert.assertEquals("Each new witness should have 1 SR_ADD record", 1, srAddCount.intValue());
+      Assert.assertNotNull("SR_ADD should be recorded for witness: " + witnessBase58,
+          srAddCount);
+      Assert.assertEquals("Each new witness should have 1 SR_ADD record", 1,
+          srAddCount.intValue());
       
-      // Collect empty blocks count
+      // Collect empty blocks count from histogram bucket
       Double witnessEmptyBlock = CollectorRegistry.defaultRegistry.getSampleValue(
-          "tron:block_empty_total", new String[] {"miner"}, new String[] {witnessBase58});
-      Assert.assertNotNull(witnessEmptyBlock);
+          "tron:block_transaction_count_bucket",
+          new String[] {"miner", "le"}, new String[] {witnessBase58, "0.0"});
+      Assert.assertNotNull("Empty block bucket should exist for witness: " + witnessBase58,
+          witnessEmptyBlock);
       totalNewWitnessEmptyBlocks += witnessEmptyBlock;
     }
     Assert.assertEquals(blocks, (int)totalNewWitnessEmptyBlocks);
@@ -176,14 +183,17 @@ public class PrometheusApiServiceTest extends BaseTest {
     Map<ByteString, String> witnessAndAccount = addTestWitnessAndAccount();
     witnessAndAccount.put(ByteString.copyFrom(address), key);
     
-    // Explicitly update WitnessScheduleStore to remove initial address, triggering SR_REMOVE metric
+    // Explicitly update WitnessScheduleStore to remove initial address,
+    // triggering SR_REMOVE metric
     List<ByteString> newActiveWitnesses = new ArrayList<>(witnessAndAccount.keySet());
     newActiveWitnesses.remove(ByteString.copyFrom(address));
     chainBaseManager.getWitnessScheduleStore().saveActiveWitnesses(newActiveWitnesses);
     
     // Update nextMaintenanceTime to trigger SR set change detection
-    long nextMaintenanceTime = chainBaseManager.getDynamicPropertiesStore().getNextMaintenanceTime();
-    chainBaseManager.getDynamicPropertiesStore().updateNextMaintenanceTime(nextMaintenanceTime + 3600_000L);
+    long nextMaintenanceTime = 
+        chainBaseManager.getDynamicPropertiesStore().getNextMaintenanceTime();
+    chainBaseManager.getDynamicPropertiesStore().updateNextMaintenanceTime(
+        nextMaintenanceTime + 3600_000L);
     
     for (int i = 0; i < blocks; i++) {
       generateBlock(witnessAndAccount);

--- a/framework/src/test/java/org/tron/core/metrics/prometheus/PrometheusApiServiceTest.java
+++ b/framework/src/test/java/org/tron/core/metrics/prometheus/PrometheusApiServiceTest.java
@@ -7,6 +7,7 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
@@ -66,7 +67,7 @@ public class PrometheusApiServiceTest extends BaseTest {
     parameter.setMetricsPrometheusEnable(true);
   }
 
-  protected void check(byte[] address) throws Exception {
+  protected void check(byte[] address, Map<ByteString, String> witnessAndAccount) throws Exception {
     Double memoryBytes = CollectorRegistry.defaultRegistry.getSampleValue(
         "system_total_physical_memory_bytes");
     Assert.assertNotNull(memoryBytes);
@@ -87,10 +88,42 @@ public class PrometheusApiServiceTest extends BaseTest {
         "tron:block_empty_total", new String[] {"miner"}, new String[] {minerBase58});
 
     Assert.assertNotNull(emptyBlock);
-    // The initial address is in the active witness list along with 2 randomly generated witnesses,
-    // so it produces blocks every 3 slots. Total empty blocks = 1 (first manual block) + blocks/3
-    // (from the loop) + 1 if blocks%3 != 0 (partial round)
-    Assert.assertEquals(emptyBlock.intValue(), 1 + blocks / 3 + (blocks % 3 != 0 ? 1 : 0));
+    Assert.assertEquals(emptyBlock.intValue(), 1);
+
+    // Check SR_REMOVE for initial address (removed when addTestWitnessAndAccount() is called)
+    Double srRemoveCount = CollectorRegistry.defaultRegistry.getSampleValue(
+        "tron:sr_set_change_total",
+        new String[] {"action", "witness"},
+        new String[] {MetricLabels.Counter.SR_REMOVE, minerBase58}
+    );
+    Assert.assertNotNull(srRemoveCount);
+    Assert.assertEquals(1, srRemoveCount.intValue());
+
+    // Check SR_ADD and empty blocks for each new witness in witnessAndAccount (excluding initial address)
+    ByteString addressByteString = ByteString.copyFrom(address);
+    double totalNewWitnessEmptyBlocks = 0;
+    for (ByteString witnessAddress : witnessAndAccount.keySet()) {
+      if (witnessAddress.equals(addressByteString)) {
+        continue; // Skip initial address
+      }
+      String witnessBase58 = StringUtil.encode58Check(witnessAddress.toByteArray());
+      
+      // Check SR_ADD
+      Double srAddCount = CollectorRegistry.defaultRegistry.getSampleValue(
+          "tron:sr_set_change_total",
+          new String[] {"action", "witness"},
+          new String[] {MetricLabels.Counter.SR_ADD, witnessBase58}
+      );
+      Assert.assertNotNull("SR_ADD should be recorded for witness: " + witnessBase58, srAddCount);
+      Assert.assertEquals("Each new witness should have 1 SR_ADD record", 1, srAddCount.intValue());
+      
+      // Collect empty blocks count
+      Double witnessEmptyBlock = CollectorRegistry.defaultRegistry.getSampleValue(
+          "tron:block_empty_total", new String[] {"miner"}, new String[] {witnessBase58});
+      Assert.assertNotNull(witnessEmptyBlock);
+      totalNewWitnessEmptyBlocks += witnessEmptyBlock;
+    }
+    Assert.assertEquals(blocks, (int)totalNewWitnessEmptyBlocks);
 
     Double errorLogs = CollectorRegistry.defaultRegistry.getSampleValue(
         "tron:error_info_total", new String[] {"net"}, new String[] {MetricLabels.UNDEFINED});
@@ -142,10 +175,20 @@ public class PrometheusApiServiceTest extends BaseTest {
 
     Map<ByteString, String> witnessAndAccount = addTestWitnessAndAccount();
     witnessAndAccount.put(ByteString.copyFrom(address), key);
+    
+    // Explicitly update WitnessScheduleStore to remove initial address, triggering SR_REMOVE metric
+    List<ByteString> newActiveWitnesses = new ArrayList<>(witnessAndAccount.keySet());
+    newActiveWitnesses.remove(ByteString.copyFrom(address));
+    chainBaseManager.getWitnessScheduleStore().saveActiveWitnesses(newActiveWitnesses);
+    
+    // Update nextMaintenanceTime to trigger SR set change detection
+    long nextMaintenanceTime = chainBaseManager.getDynamicPropertiesStore().getNextMaintenanceTime();
+    chainBaseManager.getDynamicPropertiesStore().updateNextMaintenanceTime(nextMaintenanceTime + 3600_000L);
+    
     for (int i = 0; i < blocks; i++) {
       generateBlock(witnessAndAccount);
     }
-    check(address);
+    check(address, witnessAndAccount);
   }
 
   private Map<ByteString, String> addTestWitnessAndAccount() {


### PR DESCRIPTION
## **User description**
**What does this PR do?**

Add two new metrics enhancements for better network monitoring:

1. **Block Transaction Count Histogram**
   - Replace `tron:block_empty_total` counter with `tron:block_transaction_count` histogram
   - Track transaction count distribution per block with buckets: [0, 10, 50, 100, 200, 500, 1000, 2000, 5000, 10000]
   - Empty blocks can be monitored via `le=0.0` bucket
   - Remove unused `BLOCK_EMPTY` counter

2. **SR Set Change Monitoring**
   - Add `tron:sr_set_change` counter to track SR membership changes
   - Detect SR additions and removals at each maintenance time interval
   - Labels: `action` (add/remove), `witness` (SR address)

**Changes:**
- Add overloaded `init()` method in `MetricsHistogram` for custom buckets
- Add `BLOCK_TRANSACTION_COUNT` histogram metric
- Add `SR_SET_CHANGE` counter with `SR_ADD`/`SR_REMOVE` labels
- Implement SR set change detection logic in `BlockChainMetricManager`
- Update `PrometheusApiServiceTest` with comprehensive test coverage

**Why are these changes required?**

- **Transaction histogram** provides richer insights than simple counter for network analysis while maintaining empty block detection capability
- **SR set change monitoring** enables tracking of network consensus participant changes for governance analysis

Compared to #6602, this PR provides a cleaner implementation focused solely on metrics enhancement without additional complexity.

**This PR has been tested by:**
- Unit Tests (updated `PrometheusApiServiceTest`)
- Manual Testing

**Follow up**

N/A


___

## **CodeAnt-AI Description**
**Track block transaction counts and SR membership changes in metrics**

### What Changed
- Blocks now contribute to a transaction-count histogram, including empty blocks, so empty blocks can be found from the `0` bucket instead of a separate counter.
- A new metric records when SRs are added or removed at maintenance time, making consensus member changes visible with one entry per witness.
- Test coverage was updated to check empty-block counting and SR add/remove tracking.

### Impact
`✅ Empty blocks remain observable`
`✅ Clearer network activity tracking`
`✅ Visible SR change monitoring`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
