### PR TITLE
fix(vm): release trace compression deflater

### DIFF
--- a/actuator/src/main/java/org/tron/core/vm/VMUtils.java
+++ b/actuator/src/main/java/org/tron/core/vm/VMUtils.java
@@ -111,13 +111,19 @@ public final class VMUtils {
 
   public static byte[] compress(byte[] bytes) throws IOException {
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    Deflater deflater = new Deflater();
 
-    ByteArrayInputStream in = new ByteArrayInputStream(bytes);
-    DeflaterOutputStream out = new DeflaterOutputStream(baos, new Deflater(), BUF_SIZE);
+    try {
+      ByteArrayInputStream in = new ByteArrayInputStream(bytes);
+      DeflaterOutputStream out = new DeflaterOutputStream(baos, deflater, BUF_SIZE);
 
-    write(in, out, BUF_SIZE);
+      write(in, out, BUF_SIZE);
 
-    return baos.toByteArray();
+      return baos.toByteArray();
+    } finally {
+      // DeflaterOutputStream only ends Deflaters it creates itself.
+      deflater.end();
+    }
   }
 
   public static byte[] compress(String content) throws IOException {

--- a/actuator/src/test/java/org/tron/core/vm/VMUtilsTest.java
+++ b/actuator/src/test/java/org/tron/core/vm/VMUtilsTest.java
@@ -1,0 +1,34 @@
+package org.tron.core.vm;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.nio.charset.StandardCharsets;
+import java.util.zip.Deflater;
+import org.junit.Test;
+import org.mockito.MockedConstruction;
+import org.tron.common.utils.ByteUtil;
+
+public class VMUtilsTest {
+
+  @Test
+  public void compressShouldReleaseDeflater() throws Exception {
+    try (MockedConstruction<Deflater> deflaters = mockConstruction(Deflater.class,
+        (deflater, context) -> when(deflater.finished()).thenReturn(true))) {
+      VMUtils.compress(new byte[0]);
+
+      assertEquals(1, deflaters.constructed().size());
+      verify(deflaters.constructed().get(0)).end();
+    }
+  }
+
+  @Test
+  public void compressShouldPreserveContent() throws Exception {
+    byte[] content = "VM trace compression".getBytes(StandardCharsets.UTF_8);
+
+    assertArrayEquals(content, ByteUtil.decompress(VMUtils.compress(content)));
+  }
+}


### PR DESCRIPTION
## **User description**
## What does this PR do?

Explicitly releases the `Deflater` created for VM trace compression.

`DeflaterOutputStream` does not release an externally supplied `Deflater`, so the instance must be ended by its owner. The compression helper now calls `Deflater.end()` in a `finally` block, covering both successful and exceptional execution paths.

This PR also adds tests to verify:

- The `Deflater` is explicitly released.
- Compressed VM trace content can still be decompressed without data loss.

## Additional context

`VMConfig.vmTraceCompressed()` currently always returns its default value of `false` because there is no setter or configuration-loading path. Therefore, the compression branch is not reached through the normal VM trace workflow today.

The resource-management issue still exists in the public compression helper and would become active if compression is enabled or the helper is called directly. This PR fixes the lifecycle issue without enabling compression or changing the existing VM trace format.

## Testing

```shell
./gradlew :actuator:test --tests org.tron.core.vm.VMUtilsTest


___

## **CodeAnt-AI Description**
Release compression resources safely without changing VM trace content

### What Changed
- VM trace compression now releases its compression resource after both successful and failed operations
- Compressed trace data remains fully recoverable without content loss
- Added coverage for resource release and compression round trips

### Impact
`✅ Fewer compression resource leaks`
`✅ Reliable VM trace decompression`
`✅ Safer failure handling during trace compression`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
