### PR TITLE
fix: prevent receive description self-assignment

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -132,6 +132,7 @@ subprojects {
                 disableAllChecks = true
                 excludedPaths = '.*/generated/.*'
                 errorproneArgs.addAll([
+                        '-Xep:SelfAssignment:ERROR',
                         '-Xep:StringCaseLocaleUsage:ERROR',
                         '-Xep:StringCaseLocaleUsageMethodRef:ERROR',
                 ])

--- a/framework/src/main/java/org/tron/core/capsule/ReceiveDescriptionCapsule.java
+++ b/framework/src/main/java/org/tron/core/capsule/ReceiveDescriptionCapsule.java
@@ -14,7 +14,7 @@ public class ReceiveDescriptionCapsule implements ProtoCapsule<ReceiveDescriptio
     receiveDescription = ReceiveDescription.newBuilder().build();
   }
 
-  public ReceiveDescriptionCapsule(final ReceiveDescription outputDescription) {
+  public ReceiveDescriptionCapsule(final ReceiveDescription receiveDescription) {
     this.receiveDescription = receiveDescription;
   }
 


### PR DESCRIPTION
## **User description**
## What does this PR do?

Fixes a self-assignment bug in the `ReceiveDescriptionCapsule(ReceiveDescription)` constructor.

The constructor parameter is renamed to `receiveDescription` and correctly assigned to the instance field.

This PR also enables Error Prone's `SelfAssignment` check as an error to prevent similar bugs from being introduced.

## Testing

- `./gradlew :framework:compileJava -x :framework:generateGitProperties`
- `./gradlew :framework:test --tests org.tron.core.zksnark.ShieldedReceiveTest.testReceiveDescriptionWithWrongCv -x :framework:generateGitProperties`


___

## **CodeAnt-AI Description**
Preserve supplied receive descriptions when creating receive-description records

### What Changed
- Receive descriptions passed to the constructor are now stored correctly instead of being lost or self-assigned
- Existing receive descriptions remain available for later validation and processing

### Impact
`✅ Correct receive-description data preserved`
`✅ Fewer invalid shielded receive records`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
